### PR TITLE
Restart pod containers when ConfigMap has changed

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -13,8 +13,9 @@ spec:
       {{- include "ld-relay.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:

--- a/test/golden/deployment.yaml
+++ b/test/golden/deployment.yaml
@@ -17,6 +17,8 @@ spec:
       app.kubernetes.io/instance: ld-relay-test
   template:
     metadata:
+      annotations:
+        checksum/config: 3923f8a7c823f36ae07962553a86da04cb32f180dc16a8f53c9efbc9a3e5e532
       labels:
         app.kubernetes.io/name: ld-relay
         app.kubernetes.io/instance: ld-relay-test


### PR DESCRIPTION
If a user tries to update the values of the relay proxy deployment, the
values will be applied the next time the container restarts. However, it
would be preferable if k8s knew to restart the container automatically
when something has changed.

The [Helm documentation][1] provides a solution for ensuring we
automatically roll the deployment of this container upon ConfigMap
changes. This solution matches the one provided in the initial [GitHub
Issue][2].

[1]: https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
[2]: https://github.com/launchdarkly/ld-relay-helm/issues/12