### PR TITLE
Fix changing checksum in golden file tests

### DIFF
--- a/test/golden/deployment.yaml
+++ b/test/golden/deployment.yaml
@@ -18,7 +18,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3923f8a7c823f36ae07962553a86da04cb32f180dc16a8f53c9efbc9a3e5e532
       labels:
         app.kubernetes.io/name: ld-relay
         app.kubernetes.io/instance: ld-relay-test

--- a/test/types.go
+++ b/test/types.go
@@ -29,6 +29,10 @@ func (s *TemplateGoldenTest) TestContainerGoldenTestDefaults() {
 	output := helm.RenderTemplate(s.T(), options, s.ChartPath, s.Release, s.Templates)
 	regex := regexp.MustCompile(`\s+helm.sh/chart:\s+.*`)
 	bytes := regex.ReplaceAll([]byte(output), []byte(""))
+
+	regex = regexp.MustCompile(`\s+checksum/config:\s+.*`)
+	bytes = regex.ReplaceAll(bytes, []byte(""))
+
 	output = string(bytes)
 
 	goldenFile := "golden/" + s.GoldenFileName + ".yaml"


### PR DESCRIPTION
We recently added a checksum to the deployment to ensure k8s restarted
the deployment if configuration options have changed. This change
inadvertently caused a failure in our unit tests as the checksum can
change between test runs.

This commit removes the checksum from the generated golden file so we
don't have to worry about the value changing between runs. This is
consistent with how we are handling other values that change like the
Chart version.
