### PR TITLE
Allow mounting secrets as files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ help: #! Show this help message
 	@echo 'Usage: make [target] ... '
 	@echo ''
 	@echo 'Targets:'
-	@fgrep -h '#!' $(MAKEFILE_LIST) | fgrep -v fgrep | sed -s 's/:.*#!/:/' | column -t -s":"
+	@grep -h -F '#!' $(MAKEFILE_LIST) | grep -v grep | sed 's/:.*#!/:/' | column -t -s":"
 
 .PHONY: prepare
 prepare: #! Setup the project for development

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Here's a summary of the available configuration options:
 | Key                                           | Type    | Default                                                      | Description                                                                      |
 |-----------------------------------------------|---------|--------------------------------------------------------------|----------------------------------------------------------------------------------|
 | relay.environment                             | object  | `{}`                                                         | Defines container environment variables to configure the Relay Proxy instance    |
-| relay.secrets                                 | array   | `[]`                                                         | Defines container environment variables populated from a Kubernetes secret       |
+| relay.secrets                                 | array   | `[]`                                                         | Defines container environment variables or volumes populated from k8s secrets    |
 | relay.volume                                  | object  | `{}`                                                         | Enables offline mode or references an existing config file from a defined volume |
 | replicaCount                                  | integer | `1`                                                          | Number of replicas of the relay pod                                              |
 | image.repository                              | string  | `launchdarkly/ld-relay`                                      | ld-relay image repository                                                        |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,7 +42,7 @@ You must create a Secret independently of the Helm chart installation. To store 
 kubectl create secret generic relay --from-literal=sdk-key=your-sdk-key
 ```
 
-Then, you can reference this secret name and key in your `values.yaml` file:
+You can reference this secret name and key in your `values.yaml` file to set an environment variable within the Relay Proxy container:
 
 ```yaml
 # values.yaml
@@ -64,6 +64,18 @@ relay:
     - envName: LD_ENV_YourEnvironment
       secretName: relay
       secretKey: sdk-key
+```
+
+Alternatively, secrets can be mounted directly into the Relay Proxy. Secrets are mounted under `/mnt/secrets`.
+
+```yaml
+# values.yaml
+relay:
+   secrets:
+      - volumeName: tls-cert
+        volumePath: my/cert/path.cert # This will be accessible at /mnt/secrets/my/cert/path.cert
+        secretName: relay
+        secretKey: cert
 ```
 
 ## Configuration file

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -29,19 +29,42 @@ spec:
       - name: {{ include "ld-relay.name" . }}-config
         configMap:
           name: {{ include "ld-relay.name" . }}-config
+      {{ $has_volumes := false }}
       {{- if .Values.relay.volume.definition }}
+        {{ $has_volumes = true }}
       - name: {{ include "ld-relay.name" . }}-volume
         {{- toYaml .Values.relay.volume.definition | nindent 8 }}
       {{- end }}
+      {{- range .Values.relay.secrets }}
+          {{- if .volumePath }}
+            {{ $has_volumes = true }}
+      - name: {{ .volumeName }}
+        secret:
+          secretName: {{ .secretName }}
+          items:
+            - key: {{ .secretKey }}
+              path:  {{ .volumePath }}
+          {{- end }}
+      {{- end }}
+
       serviceAccountName: {{ include "ld-relay.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          {{- if .Values.relay.volume.definition }}
+          {{- if $has_volumes }}
           volumeMounts:
+            {{- if .Values.relay.volume.definition }}
             - name: {{ include "ld-relay.name" . }}-volume
               mountPath: /mnt/volume
+            {{- end }}
+            {{- range .Values.relay.secrets }}
+              {{- if .volumePath }}
+            - name: {{ .volumeName }}
+              mountPath: /mnt/secrets/
+              readOnly: true
+              {{- end }}
+            {{- end }}
           {{- end }}
 
           {{- if .Values.relay.volume.config }}
@@ -55,11 +78,13 @@ spec:
             {{- end }}
 
             {{- range .Values.relay.secrets }}
-              - name: {{ .envName }}
-                valueFrom:
-                    secretKeyRef:
-                      key: {{ .secretKey }}
-                      name: {{ .secretName }}
+              {{- if .envName }}
+            - name: {{ .envName }}
+              valueFrom:
+                  secretKeyRef:
+                    key: {{ .secretKey }}
+                    name: {{ .secretName }}
+              {{- end }}
             {{- end }}
           envFrom:
             - configMapRef:

--- a/test/golden/deployment.yaml
+++ b/test/golden/deployment.yaml
@@ -26,6 +26,8 @@ spec:
       - name: ld-relay-config
         configMap:
           name: ld-relay-config
+      
+
       serviceAccountName: ld-relay-test
       securityContext:
         {}

--- a/test/types.go
+++ b/test/types.go
@@ -2,11 +2,12 @@ package test
 
 import (
 	"flag"
+	"io/ioutil"
+	"regexp"
+
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/stretchr/testify/suite"
-	"io/ioutil"
-	"regexp"
 )
 
 var update = flag.Bool("update-golden", false, "update golden test output files")

--- a/values.yaml
+++ b/values.yaml
@@ -109,10 +109,18 @@ relay:
     # LD_ENV_MyEnvironment: your-sdk-key
     # USE_REDIS: true
 
-  # Set environment variables in the relay container with values pulled from k8s secrets
-  # These environment variables should match the ones documented by the relay proxy at https://github.com/launchdarkly/ld-relay
+  # Use k8s secrets to either set environment variables or to mount secrets as files in the relay container.
   secrets: []
+    # Set environment variables in the relay container with values pulled from k8s secrets by specifying the envName property.
+    # These environment variables should match the ones documented by the relay proxy at https://github.com/launchdarkly/ld-relay
     # - envName: REDIS_PASSWORD
+    #   secretName: relay-proxy
+    #   secretKey: redis-password
+    #
+    # Setting the volumePath and volumeName values will mount the specified secret as a file into the container.
+    # All file paths are stored under /mnt/secrets
+    # - volumePath: path
+    #   volumeName: name
     #   secretName: relay-proxy
     #   secretKey: redis-password
 


### PR DESCRIPTION
The relay proxy allows specifying a custom TLS certificate. At least one
customer has requested the ability to load this certificate from a k8s
secret.

This commit allows users of this chart to specify secrets in two
flavors-- either to be loaded as environment variables or to be mounted
as a file directly into the container.
