### PR TITLE
Include all previous published versions on GH pages

### DIFF
--- a/.ldrelease/build.sh
+++ b/.ldrelease/build.sh
@@ -17,7 +17,9 @@ helm repo index . --url https://launchdarkly.github.io/ld-relay-helm --merge "$G
 
 cp ld-relay-"$LD_RELEASE_VERSION".tgz "$LD_RELEASE_ARTIFACTS_DIR"
 
-# We can place the .tgz and updated index.yaml files into the release docs
-# directory, and releaser will handle updating the gh-pages branch for us.
+# We can place the new .tgz, all existing .tgz files, and the updated
+# index.yaml files into the release docs directory, and releaser will handle
+# updating the gh-pages branch for us.
 mv ld-relay-"$LD_RELEASE_VERSION".tgz "$LD_RELEASE_DOCS_DIR"
 mv index.yaml "$LD_RELEASE_DOCS_DIR"
+mv "$GH_PAGES_DIR"/*.tgz "$LD_RELEASE_DOCS_DIR"


### PR DESCRIPTION
When releaser is publishing changes to GH pages, it does not attempt to merge new files in with the old. Instead, it completely replaces that branch with the files you store in $LD_RELEASE_DOCS_DIR.

Our helm chart needs the newly created archive file, the newly created index.yaml file, but it also needs all previously published archives, which this commit addresses.

On the release prior to this one, I restored all previous published archive files by hand, so going forward this change should be all that is necessary for correct releases.