### PR TITLE
feat: Default to 7.2.1 version of the relay proxy

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -29,4 +29,4 @@ version: 1.2.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "6.7.12"
+appVersion: "7.2.1"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-> **Warning**
->
-> By default, 1.x releases of the Helm Chart install the 6.x version of the Relay Proxy. This version is NOT compatible with [LaunchDarkly Contexts](https://docs.launchdarkly.com/guides/flags/intro-contexts).
->
-> Consider upgrading to a later version of this Helm Chart to receive context support by default.
-
 # LaunchDarkly Relay Proxy Helm Chart
 
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/launchdarkly/ld-relay-helm/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/launchdarkly/ld-relay-helm/tree/main)

--- a/test/golden/config.yaml
+++ b/test/golden/config.yaml
@@ -7,6 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: ld-relay
     app.kubernetes.io/instance: ld-relay-test
-    app.kubernetes.io/version: "6.7.12"
+    app.kubernetes.io/version: "7.2.1"
     app.kubernetes.io/managed-by: Helm
 data:

--- a/test/golden/deployment.yaml
+++ b/test/golden/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: ld-relay
     app.kubernetes.io/instance: ld-relay-test
-    app.kubernetes.io/version: "6.7.12"
+    app.kubernetes.io/version: "7.2.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -40,7 +40,7 @@ spec:
                 name: ld-relay-config
           securityContext:
             {}
-          image: "launchdarkly/ld-relay:6.7.12"
+          image: "launchdarkly/ld-relay:7.2.1"
           imagePullPolicy: IfNotPresent
           ports:
               - containerPort: 8030

--- a/test/golden/ingress.yaml
+++ b/test/golden/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: ld-relay
     app.kubernetes.io/instance: ld-relay-test
-    app.kubernetes.io/version: "6.7.12"
+    app.kubernetes.io/version: "7.2.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   rules:

--- a/test/golden/service.yaml
+++ b/test/golden/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: ld-relay
     app.kubernetes.io/instance: ld-relay-test
-    app.kubernetes.io/version: "6.7.12"
+    app.kubernetes.io/version: "7.2.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/test/golden/serviceaccount.yaml
+++ b/test/golden/serviceaccount.yaml
@@ -7,5 +7,5 @@ metadata:
   labels:
     app.kubernetes.io/name: ld-relay
     app.kubernetes.io/instance: ld-relay-test
-    app.kubernetes.io/version: "6.7.12"
+    app.kubernetes.io/version: "7.2.1"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
Now that the users to context work has reached GA, our helm chart can
start installing the context-aware version of the proxy by default.