### PR TITLE
feat: Introduce top level pod configuration value

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,11 @@ Here's a summary of the available configuration options:
 | serviceAccount.create                         | bool    | `true`                                                       | Specifies whether a service account should be created                            |
 | serviceAccount.annotations                    | object  | `{}`                                                         | Annotations to add to the service account                                        |
 | serviceAccount.name                           | string  | `""`                                                         | The name of the service account                                                  |
-| podAnnotations                                | object  | `{}`                                                         | Pod annotations                                                                  |
-| podLabels                                     | object  | `{}`                                                         | Additional pod labels                                                            |
-| podSecurityContext                            | object  | `{}`                                                         | Pod security context                                                             |
+| podAnnotations                                | object  | `{}`                                                         | Pod annotations (deprecated: use pod.annotations instead)                        |
+| podSecurityContext                            | object  | `{}`                                                         | Pod security context (deprecated: use pod.securityContext instead)               |
+| pod.annotations                               | object  | `{}`                                                         | Pod annotations                                                                  |
+| pod.labels                                    | object  | `{}`                                                         | Pod labels                                                                       |
+| pod.securityContext                           | object  | `{}`                                                         | Pod security context                                                             |
 | securityContext                               | object  | `{}`                                                         | Container security context                                                       |
 | service.type                                  | string  | `ClusterIP`                                                  | Kubernetes service type                                                          |
 | service.annotations                           | object  | `{}`                                                         | Annotations to add to the service                                                |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -15,12 +15,18 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
-      {{- with .Values.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.pod.annotations }}
+        {{- with .Values.pod.annotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- else }}
+        {{- with .Values.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       labels:
         {{- include "ld-relay.selectorLabels" . | nindent 8 }}
-        {{- with .Values.podLabels }}
+        {{- with .Values.pod.labels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
@@ -52,7 +58,11 @@ spec:
 
       serviceAccountName: {{ include "ld-relay.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- if .Values.pod.securityContext }}
+          {{- toYaml .Values.pod.securityContext | nindent 8 }}
+        {{- else }}
+          {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           {{- if $has_volumes }}

--- a/values.yaml
+++ b/values.yaml
@@ -24,11 +24,19 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+pod:
+  # Annotations to add to the pod. If provided, will take precedence over podAnnotations
+  annotations: {}
+  # Labels to add to the pod.
+  labels: {}
+  # Security context applied to the pod. If provided, will take precedence over podSecurityContext
+  securityContext: {}
+    # fsGroup: 2000
+
+# Deprecated: Use pod.annotations instead
 podAnnotations: {}
 
-# Additional labels added to the pod
-podLabels: {}
-
+# Deprecated: Use pod.securityContext instead
 podSecurityContext: {}
   # fsGroup: 2000
 


### PR DESCRIPTION
The chart initially supported a few pod configuration options at the top level -- podAnnotations and podSecurityContext. Now that we want to support labels on the pod, we are moving the preferred configuration under a single pod values option. This new option supports

- pod.annotations :: Takes precedence over podAnnotations
- pod.labels
- pod.securityContext :: Takes precedence over podSecurityContext

The legacy configuration options will continue to be supported until the next major release.