### PR TITLE
fix: Allow multiple secrets to be mounted as volumes

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -72,8 +72,7 @@ Alternatively, secrets can be mounted directly into the Relay Proxy. Secrets are
 # values.yaml
 relay:
    secrets:
-      - volumeName: tls-cert
-        volumePath: my/cert/path.cert # This will be accessible at /mnt/secrets/my/cert/path.cert
+      - volumePath: my/cert/path.cert # This will be accessible at /mnt/secrets/my/cert/path.cert
         secretName: relay
         secretKey: cert
 ```

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -44,18 +44,28 @@ spec:
       - name: {{ include "ld-relay.name" . }}-volume
         {{- toYaml .Values.relay.volume.definition | nindent 8 }}
       {{- end }}
+      {{ $has_projected_volume := false }}
       {{- range .Values.relay.secrets }}
-          {{- if .volumePath }}
-            {{ $has_volumes = true }}
-      - name: {{ .volumeName }}
-        secret:
-          secretName: {{ .secretName }}
-          items:
-            - key: {{ .secretKey }}
-              path:  {{ .volumePath }}
-          {{- end }}
+        {{- if .volumePath }}
+          {{ $has_projected_volume = true }}
+        {{- end }}
       {{- end }}
 
+      {{- if $has_projected_volume }}
+      - name: {{ include "ld-relay.name" . }}-projected-volume
+        projected:
+          sources:
+            {{- range .Values.relay.secrets }}
+              {{- if .volumePath }}
+                {{ $has_volumes = true }}
+            - secret:
+                name: {{ .secretName }}
+                items:
+                  - key: {{ .secretKey }}
+                    path:  {{ .volumePath }}
+              {{- end }}
+            {{- end }}
+      {{- end }}
       serviceAccountName: {{ include "ld-relay.serviceAccountName" . }}
       securityContext:
         {{- if .Values.pod.securityContext }}
@@ -71,12 +81,10 @@ spec:
             - name: {{ include "ld-relay.name" . }}-volume
               mountPath: /mnt/volume
             {{- end }}
-            {{- range .Values.relay.secrets }}
-              {{- if .volumePath }}
-            - name: {{ .volumeName }}
+            {{- if $has_projected_volume }}
+            - name: {{ include "ld-relay.name" . }}-projected-volume
               mountPath: /mnt/secrets/
               readOnly: true
-              {{- end }}
             {{- end }}
           {{- end }}
 

--- a/test/golden/deployment.yaml
+++ b/test/golden/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         configMap:
           name: ld-relay-config
       
-
+      
       serviceAccountName: ld-relay-test
       securityContext:
         {}

--- a/values.yaml
+++ b/values.yaml
@@ -140,10 +140,9 @@ relay:
     #   secretName: relay-proxy
     #   secretKey: redis-password
     #
-    # Setting the volumePath and volumeName values will mount the specified secret as a file into the container.
+    # Setting volumePath will mount the specified secret as a file into the container.
     # All file paths are stored under /mnt/secrets
     # - volumePath: path
-    #   volumeName: name
     #   secretName: relay-proxy
     #   secretKey: redis-password
 


### PR DESCRIPTION
When specifying a volume on a container, you cannot share a mountPath.
We were incorrectly trying to do this if more than 1 secret was to be
mounted as a volume.

Our documentation states that all secret volumes will be mounted under
`/mnt/secret`. And indeed, if you attempted to mount a single secret
under the name `key`, you would find the file at `/mnt/secret/key`.

To keep this consistent, we are updating the template to generate a
single projected volume[1] which contains all the secret values, allowing
us to continue mounting multiple secrets relative to `/mnt/secret`.

[1]: https://kubernetes.io/docs/concepts/storage/projected-volumes/
