### PR TITLE
fix: Bump default relay proxy version from 8.10.5 to 8.19.1

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -29,4 +29,4 @@ version: 3.6.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "8.10.5"
+appVersion: "8.19.1"

--- a/test/golden/config.yaml
+++ b/test/golden/config.yaml
@@ -7,6 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: ld-relay
     app.kubernetes.io/instance: ld-relay-test
-    app.kubernetes.io/version: "8.10.5"
+    app.kubernetes.io/version: "8.19.1"
     app.kubernetes.io/managed-by: Helm
 data:

--- a/test/golden/deployment.yaml
+++ b/test/golden/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: ld-relay
     app.kubernetes.io/instance: ld-relay-test
-    app.kubernetes.io/version: "8.10.5"
+    app.kubernetes.io/version: "8.19.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -39,7 +39,7 @@ spec:
                 name: ld-relay-test-config
           securityContext:
             {}
-          image: "launchdarkly/ld-relay:8.10.5"
+          image: "launchdarkly/ld-relay:8.19.1"
           imagePullPolicy: IfNotPresent
           ports:
               - containerPort: 8030

--- a/test/golden/ingress.yaml
+++ b/test/golden/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: ld-relay
     app.kubernetes.io/instance: ld-relay-test
-    app.kubernetes.io/version: "8.10.5"
+    app.kubernetes.io/version: "8.19.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   rules:

--- a/test/golden/service.yaml
+++ b/test/golden/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: ld-relay
     app.kubernetes.io/instance: ld-relay-test
-    app.kubernetes.io/version: "8.10.5"
+    app.kubernetes.io/version: "8.19.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/test/golden/serviceaccount.yaml
+++ b/test/golden/serviceaccount.yaml
@@ -7,5 +7,5 @@ metadata:
   labels:
     app.kubernetes.io/name: ld-relay
     app.kubernetes.io/instance: ld-relay-test
-    app.kubernetes.io/version: "8.10.5"
+    app.kubernetes.io/version: "8.19.1"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

The chart (v3.6.0) has `appVersion: "8.10.5"` hardcoded in Chart.yaml, but the latest stable Relay Proxy is 8.19.1. Deployments silently run the outdated version unless `image.tag` is set explicitly in values.

**Describe the solution you've provided**

Bumps the `appVersion` in Chart.yaml from `8.10.5` to `8.19.1` so that the default deployment uses the latest stable v8 relay proxy release.

**Describe alternatives you've considered**

N/A

**Additional context**

Reference: https://github.com/launchdarkly/ld-relay-helm/pull/69

Link to Devin session: https://app.devin.ai/sessions/73b9015f9dea4e5d82964673755a2dfb
Requested by: @keelerm84

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default `ld-relay` container image tag (via `.Chart.AppVersion`) and associated labels, which could alter runtime behavior for users relying on chart defaults. Scope is limited to a version bump with updated golden manifests.
> 
> **Overview**
> Updates the chart’s default Relay Proxy version by bumping `Chart.yaml` `appVersion` from `8.10.5` to `8.19.1`, which in turn changes the default image tag (`image.tag | default .Chart.AppVersion`).
> 
> Refreshes the golden test manifests to expect the new `app.kubernetes.io/version` label value and `launchdarkly/ld-relay:8.19.1` image reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56877ed19a78140850cf3ff168e9dcd0c491b16b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->