### PR TITLE
feat: expose revisionHistoryLimit and dnsConfig/dnsPolicy as configurable values

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Here's a summary of the available configuration options:
 | autoscaling.targetMemoryUtilizationPercentage | integer | `80`                                                         | Configures memory as an average utilization metrics resource                                             |
 | autoscaling.behavior                          | object  | `null`                                                       | Optional HPA scale behavior (requires Kubernetes >= 1.18)                                                |
 | deployment.strategy                           | object  | `null`                                                       | Optional rolling update strategy for the deployment                                                      |
+| deployment.revisionHistoryLimit               | integer | `null`                                                       | Optional number of old ReplicaSets to retain for rollback (Kubernetes default `10`)                      |
 | nodeSelector                                  | object  | `{}`                                                         | Selector to target node placement for the relay pod                                                      |
 | tolerations                                   | array   | `[]`                                                         | Specify pod tolerations                                                                                  |
 | affinity                                      | object  | `{}`                                                         | Specify pod affinity                                                                                     |
@@ -91,6 +92,8 @@ Here's a summary of the available configuration options:
 | pod.disruptionBudget.maxUnavailable           | string  | `""`                                                         | Maximum number of pods that are unavailable after eviction as number or percentage                       |
 | pod.topologySpreadConstraints                 | array   | `[]`                                                         | Specify the topology spread constrait definitions to apply to the relay deployment                       |
 | pod.priorityClassName                         | string  | `""`                                                         | Specify a PriorityClass for the pod                                                                      |
+| pod.dnsPolicy                                 | string  | `""`                                                         | Optional pod DNS policy (Kubernetes default `ClusterFirst`); set to `None` when supplying a custom dnsConfig |
+| pod.dnsConfig                                 | object  | `{}`                                                         | Optional pod DNS configuration (nameservers, searches, options)                                          |
 
 ## Learn more
 

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -9,6 +9,9 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  {{- with .Values.deployment.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "ld-relay.selectorLabels" . | nindent 6 }}
@@ -189,5 +192,12 @@ spec:
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.pod.dnsPolicy }}
+      dnsPolicy: {{ . }}
+      {{- end }}
+      {{- with .Values.pod.dnsConfig }}
+      dnsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -9,8 +9,8 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
-  {{- with .Values.deployment.revisionHistoryLimit }}
-  revisionHistoryLimit: {{ . }}
+  {{- if not (kindIs "invalid" .Values.deployment.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ .Values.deployment.revisionHistoryLimit }}
   {{- end }}
   selector:
     matchLabels:

--- a/test/deployment_test.go
+++ b/test/deployment_test.go
@@ -788,6 +788,23 @@ func (s *TemplateTest) TestCanSetRevisionHistoryLimit() {
 	s.Require().Equal(int32(3), *deployment.Spec.RevisionHistoryLimit)
 }
 
+func (s *TemplateTest) TestCanSetRevisionHistoryLimitToZero() {
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"deployment.revisionHistoryLimit": "0",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.Namespace),
+	}
+
+	output := helm.RenderTemplate(s.T(), options, s.ChartPath, s.Release, []string{"templates/deployment.yaml"})
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// 0 is a valid value (retain no old ReplicaSets) and must not be treated as unset.
+	s.Require().NotNil(deployment.Spec.RevisionHistoryLimit)
+	s.Require().Equal(int32(0), *deployment.Spec.RevisionHistoryLimit)
+}
+
 func (s *TemplateTest) TestDnsConfigNotSetByDefault() {
 	options := &helm.Options{
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.Namespace),

--- a/test/deployment_test.go
+++ b/test/deployment_test.go
@@ -760,6 +760,73 @@ func (s *TemplateTest) TestRollingUpdateStrategyNotSetByDefault() {
 	s.Require().Empty(deployment.Spec.Strategy.Type)
 }
 
+func (s *TemplateTest) TestRevisionHistoryLimitNotSetByDefault() {
+	options := &helm.Options{
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.Namespace),
+	}
+
+	output := helm.RenderTemplate(s.T(), options, s.ChartPath, s.Release, []string{"templates/deployment.yaml"})
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	s.Require().Nil(deployment.Spec.RevisionHistoryLimit)
+}
+
+func (s *TemplateTest) TestCanSetRevisionHistoryLimit() {
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"deployment.revisionHistoryLimit": "3",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.Namespace),
+	}
+
+	output := helm.RenderTemplate(s.T(), options, s.ChartPath, s.Release, []string{"templates/deployment.yaml"})
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	s.Require().NotNil(deployment.Spec.RevisionHistoryLimit)
+	s.Require().Equal(int32(3), *deployment.Spec.RevisionHistoryLimit)
+}
+
+func (s *TemplateTest) TestDnsConfigNotSetByDefault() {
+	options := &helm.Options{
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.Namespace),
+	}
+
+	output := helm.RenderTemplate(s.T(), options, s.ChartPath, s.Release, []string{"templates/deployment.yaml"})
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	s.Require().Empty(deployment.Spec.Template.Spec.DNSPolicy)
+	s.Require().Nil(deployment.Spec.Template.Spec.DNSConfig)
+}
+
+func (s *TemplateTest) TestCanSetDnsPolicyAndDnsConfig() {
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"pod.dnsPolicy":                 "None",
+			"pod.dnsConfig.nameservers[0]":  "1.1.1.1",
+			"pod.dnsConfig.searches[0]":     "ns1.svc.cluster-domain.example",
+			"pod.dnsConfig.options[0].name": "ndots",
+		},
+		SetStrValues: map[string]string{
+			"pod.dnsConfig.options[0].value": "2",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.Namespace),
+	}
+
+	output := helm.RenderTemplate(s.T(), options, s.ChartPath, s.Release, []string{"templates/deployment.yaml"})
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	s.Require().Equal(corev1.DNSPolicy("None"), deployment.Spec.Template.Spec.DNSPolicy)
+	s.Require().NotNil(deployment.Spec.Template.Spec.DNSConfig)
+	s.Require().Equal([]string{"1.1.1.1"}, deployment.Spec.Template.Spec.DNSConfig.Nameservers)
+	s.Require().Equal([]string{"ns1.svc.cluster-domain.example"}, deployment.Spec.Template.Spec.DNSConfig.Searches)
+	s.Require().Equal("ndots", deployment.Spec.Template.Spec.DNSConfig.Options[0].Name)
+	s.Require().Equal("2", *deployment.Spec.Template.Spec.DNSConfig.Options[0].Value)
+}
+
 func (s *TemplateTest) TestCanSetRollingUpdateStrategy() {
 	options := &helm.Options{
 		SetValues: map[string]string{

--- a/values.yaml
+++ b/values.yaml
@@ -12,6 +12,9 @@ deployment:
     # rollingUpdate:
     #   maxSurge: 1
     #   maxUnavailable: 0
+  # Optional number of old ReplicaSets to retain for rollback.
+  # When unset, Kubernetes applies its default (10).
+  revisionHistoryLimit: null
 
 image:
   # Use the official LaunchDarkly relay proxy image
@@ -84,6 +87,18 @@ pod:
   # - maxSkew: 1
   #   topologyKey: topology.kubernetes.io/zone
   #   whenUnsatisfiable: DoNotSchedule
+  # Pod DNS policy. When unset, Kubernetes applies its default ("ClusterFirst").
+  # Set to "None" when supplying a fully custom dnsConfig below.
+  dnsPolicy: ""
+  # Pod DNS configuration. Merged with dnsPolicy per the Kubernetes Pod DNS rules.
+  dnsConfig: {}
+    # nameservers:
+    #   - 1.1.1.1
+    # searches:
+    #   - ns1.svc.cluster-domain.example
+    # options:
+    #   - name: ndots
+    #     value: "2"
 
 # Optional termination grace period in seconds for graceful pod shutdown
 # terminationGracePeriodSeconds: 90


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

---

## Context

Two common pod/deployment-spec fields are not currently exposable through the chart, so operators have to vendor and patch templates to set them:

- **`revisionHistoryLimit`** — on large/frequently-rolled deployments the default of 10 retained ReplicaSets is often trimmed (e.g. to `1`–`3`) to reduce etcd/API clutter. There is no way to set it without patching `deployment.yaml`.
- **`dnsConfig` / `dnsPolicy`** — needed for custom resolver setups (extra nameservers, `ndots` tuning, additional search domains), which is common when running ld-relay alongside service meshes or split-horizon DNS.

This follows the same opt-in, null-default pattern recently added in #117 for `deployment.strategy` and `autoscaling.behavior`.

## Changes

### 1. `deployment.revisionHistoryLimit`

Adds a `deployment.revisionHistoryLimit` value (defaulting to `null`) rendered into the `Deployment` spec's `revisionHistoryLimit` field when set. When unset, the field is omitted and Kubernetes applies its default of `10`.

### 2. `pod.dnsPolicy` and `pod.dnsConfig`

Adds `pod.dnsPolicy` (defaulting to `""`) and `pod.dnsConfig` (defaulting to `{}`), rendered into the pod spec's `dnsPolicy` / `dnsConfig` fields when set. When unset, neither field is emitted and Kubernetes applies its defaults (`ClusterFirst`). Set `dnsPolicy: None` when supplying a fully custom `dnsConfig`.

```yaml
deployment:
  revisionHistoryLimit: 3

pod:
  dnsPolicy: None
  dnsConfig:
    nameservers:
      - 1.1.1.1
    searches:
      - ns1.svc.cluster-domain.example
    options:
      - name: ndots
        value: "2"
```

All three are fully backward-compatible: each is gated behind `{{- with }}`, so default rendered output is byte-for-byte unchanged (the existing golden-file tests pass without regeneration).

## Tests added

- `TestRevisionHistoryLimitNotSetByDefault`
- `TestCanSetRevisionHistoryLimit`
- `TestDnsConfigNotSetByDefault`
- `TestCanSetDnsPolicyAndDnsConfig`

`make test` passes locally, and the `README.md` configuration table documents all three values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in Helm values with unchanged default renders; affects rollout history and pod DNS only when operators set them.
> 
> **Overview**
> Operators can configure **Deployment** rollback history and **pod DNS** without patching chart templates.
> 
> **`deployment.revisionHistoryLimit`** is optional (`null` by default). When set, it is rendered on the Deployment; when unset, the field is omitted so Kubernetes keeps its default of 10. Rendering uses `kindIs "invalid"` so **`0`** is honored (no old ReplicaSets retained).
> 
> **`pod.dnsPolicy`** and **`pod.dnsConfig`** are optional (`""` / `{}` by default). They are emitted on the pod spec only when set, following the same opt-in pattern as `deployment.strategy`.
> 
> `values.yaml`, **README** configuration table, and **Helm template tests** cover defaults, explicit values, and DNS nameservers/searches/options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8de3ae756bbfe298d6d3676808ff55847acbeaf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->