### PR TITLE
feat: Add support for Gateway API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 helm-repo
+.idea

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ Here's a summary of the available configuration options:
 | ingress.annotations                           | object  | `{}`                                                         | Ingress annotations                                                                                      |
 | ingress.hosts                                 | array   | `[]`                                                         | List of host rules                                                                                       |
 | ingress.tls                                   | array   | `[]`                                                         | Ingress TLS configuration                                                                                |
+| httpRoute.enabled                             | bool    | `false`                                                      | Enables Gateway API HTTPRoute                                                                            |
+| httpRoute.annotations                         | object  | `{}`                                                         | HTTPRoute annotations                                                                                    |
+| httpRoute.parentRefs                          | array   | `[]`                                                         | List of Gateway parent references this route attaches to                                                 |
+| httpRoute.hostnames                           | array   | `[]`                                                         | List of hostnames this route matches                                                                     |
+| httpRoute.rules                               | array   | `[]`                                                         | List of routing rules (path matches + backend port); routes to the chart's Service                       |
 | resources                                     | object  | `{}`                                                         | Resource requirements for the relay container                                                            |
 | autoscaling.enabled                           | bool    | `false`                                                      | Enables HorizontalPodAutoscaler                                                                          |
 | autoscaling.minReplicas                       | integer | `1`                                                          | Sets minimum number of running replicas                                                                  |
@@ -94,6 +99,8 @@ Here's a summary of the available configuration options:
 | pod.priorityClassName                         | string  | `""`                                                         | Specify a PriorityClass for the pod                                                                      |
 | pod.dnsPolicy                                 | string  | `""`                                                         | Optional pod DNS policy (Kubernetes default `ClusterFirst`); set to `None` when supplying a custom dnsConfig |
 | pod.dnsConfig                                 | object  | `{}`                                                         | Optional pod DNS configuration (nameservers, searches, options)                                          |
+
+`httpRoute` requires the [Gateway API](https://gateway-api.sigs.k8s.io/) CRDs (`gateway.networking.k8s.io`) to already be installed in the cluster, along with a `Gateway` resource for the route to attach to. Use either `ingress` or `httpRoute`, not both.
 
 ## Learn more
 

--- a/README.md
+++ b/README.md
@@ -77,9 +77,14 @@ Here's a summary of the available configuration options:
 | ingress.tls                                   | array   | `[]`                                                         | Ingress TLS configuration                                                                                |
 | httpRoute.enabled                             | bool    | `false`                                                      | Enables Gateway API HTTPRoute                                                                            |
 | httpRoute.annotations                         | object  | `{}`                                                         | HTTPRoute annotations                                                                                    |
-| httpRoute.parentRefs                          | array   | `[]`                                                         | List of Gateway parent references this route attaches to                                                 |
+| httpRoute.parentRefs                          | array   | `[]`                                                         | List of Gateway parent references this route attaches to (full ParentReference schema; rendered as-is)   |
 | httpRoute.hostnames                           | array   | `[]`                                                         | List of hostnames this route matches                                                                     |
-| httpRoute.rules                               | array   | `[]`                                                         | List of routing rules (path matches + backend port); routes to the chart's Service                       |
+| httpRoute.rules                               | array   | `[]`                                                         | List of routing rules; see the fields below                                                              |
+| httpRoute.rules[].matches                     | array   | `[]`                                                         | Full Gateway API match schema (path, headers, method, queryParams); rendered as-is                       |
+| httpRoute.rules[].filters                     | array   | `[]`                                                         | Full Gateway API filter schema (header modifiers, redirect, URL rewrite, mirror); rendered as-is         |
+| httpRoute.rules[].timeouts                    | object  | `{}`                                                         | Gateway API timeouts (request, backendRequest); rendered as-is                                           |
+| httpRoute.rules[].port                        | integer | `nil`                                                        | Convenience: routes the rule's backend to the chart's Service on this port                               |
+| httpRoute.rules[].backendRefs                 | array   | `[]`                                                         | Explicit backends (weighting, mirroring, external); overrides the `port` convenience when set            |
 | resources                                     | object  | `{}`                                                         | Resource requirements for the relay container                                                            |
 | autoscaling.enabled                           | bool    | `false`                                                      | Enables HorizontalPodAutoscaler                                                                          |
 | autoscaling.minReplicas                       | integer | `1`                                                          | Sets minimum number of running replicas                                                                  |
@@ -101,6 +106,8 @@ Here's a summary of the available configuration options:
 | pod.dnsConfig                                 | object  | `{}`                                                         | Optional pod DNS configuration (nameservers, searches, options)                                          |
 
 `httpRoute` requires the [Gateway API](https://gateway-api.sigs.k8s.io/) CRDs (`gateway.networking.k8s.io`) to already be installed in the cluster, along with a `Gateway` resource for the route to attach to. Use either `ingress` or `httpRoute`, not both.
+
+For each rule, set `port` to route to this chart's Service, or set `backendRefs` explicitly. `backendRefs` takes precedence over `port` when both are given, and (unlike `port`) can target any Service, including another namespace. A rule with no `matches` matches every request and publishes the entire relay -- including admin/metrics endpoints -- on the route's hostname, so add explicit `matches` unless a catch-all is intended.
 
 ## Learn more
 

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -11,7 +11,11 @@
 {{- range $hostname := .Values.httpRoute.hostnames }}
   {{- range $.Values.httpRoute.rules }}
     {{- range .matches }}
-      {{- $urls = append $urls (printf "http://%s%s" $hostname .path.value) }}
+      {{- with .path }}
+        {{- with .value }}
+          {{- $urls = append $urls (printf "http://%s%s" $hostname .) }}
+        {{- end }}
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}
@@ -19,6 +23,7 @@
 {{- range $urls }}
   {{ . }}
 {{- end }}
+  NOTE: the scheme above is a guess -- it depends on the listener your Gateway routes through (e.g. https for a TLS listener).
 {{- else }}
   Run 'kubectl get --namespace {{ $namespace }} httproute {{ include "ld-relay.fullname" . }}' to find the hostname(s) configured on your Gateway.
 {{- end }}

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -6,7 +6,7 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
-{{- else if .Values.httpRoute.enabled }}
+{{- else if and .Values.httpRoute.enabled .Values.httpRoute.hostnames }}
 {{- range $hostname := .Values.httpRoute.hostnames }}
   {{- range $.Values.httpRoute.rules }}
     {{- range .matches }}

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -6,13 +6,21 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
-{{- else if and .Values.httpRoute.enabled .Values.httpRoute.hostnames }}
+{{- else if .Values.httpRoute.enabled }}
+{{- $urls := list }}
 {{- range $hostname := .Values.httpRoute.hostnames }}
   {{- range $.Values.httpRoute.rules }}
     {{- range .matches }}
-  http://{{ $hostname }}{{ .path.value }}
+      {{- $urls = append $urls (printf "http://%s%s" $hostname .path.value) }}
     {{- end }}
   {{- end }}
+{{- end }}
+{{- if $urls }}
+{{- range $urls }}
+  {{ . }}
+{{- end }}
+{{- else }}
+  Run 'kubectl get --namespace {{ $namespace }} httproute {{ include "ld-relay.fullname" . }}' to find the hostname(s) configured on your Gateway.
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ $namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "ld-relay.fullname" . }})

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -6,6 +6,14 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
+{{- else if .Values.httpRoute.enabled }}
+{{- range $hostname := .Values.httpRoute.hostnames }}
+  {{- range $.Values.httpRoute.rules }}
+    {{- range .matches }}
+  http://{{ $hostname }}{{ .path.value }}
+    {{- end }}
+  {{- end }}
+{{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ $namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "ld-relay.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ $namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/templates/httproute.yaml
+++ b/templates/httproute.yaml
@@ -14,34 +14,36 @@ metadata:
 spec:
   {{- with .Values.httpRoute.parentRefs }}
   parentRefs:
-    {{- range . }}
-    - name: {{ .name }}
-      {{- with .namespace }}
-      namespace: {{ . }}
-      {{- end }}
-      {{- with .sectionName }}
-      sectionName: {{ . }}
-      {{- end }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with .Values.httpRoute.hostnames }}
   hostnames:
-    {{- range . }}
-    - {{ . | quote }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
     {{- range .Values.httpRoute.rules }}
+    {{- if not (or .port .backendRefs) }}
+      {{- fail "httpRoute.rules[]: each rule needs a `port` (routes to the chart Service) or an explicit `backendRefs`" }}
+    {{- end }}
     - {{- with .matches }}
       matches:
-        {{- range . }}
-        - path:
-            type: {{ .path.type }}
-            value: {{ .path.value }}
-        {{- end }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .backendRefs }}
+      backendRefs:
+        {{- toYaml .backendRefs | nindent 8 }}
+      {{- else }}
       backendRefs:
         - name: {{ $fullName }}
-          port: {{ .port }}
+          port: {{ .port | int }}
+      {{- end }}
     {{- end }}
 {{- end }}

--- a/templates/httproute.yaml
+++ b/templates/httproute.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $fullName := include "ld-relay.fullname" . -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ include "ld-relay.namespace" . }}
+  labels:
+    {{- include "ld-relay.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httpRoute.parentRefs }}
+  parentRefs:
+    {{- range . }}
+    - name: {{ .name }}
+      {{- with .namespace }}
+      namespace: {{ . }}
+      {{- end }}
+      {{- with .sectionName }}
+      sectionName: {{ . }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.httpRoute.rules }}
+    - {{- with .matches }}
+      matches:
+        {{- range . }}
+        - path:
+            type: {{ .path.type }}
+            value: {{ .path.value }}
+        {{- end }}
+      {{- end }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ .port }}
+    {{- end }}
+{{- end }}

--- a/test/golden/httproute-full.yaml
+++ b/test/golden/httproute-full.yaml
@@ -14,14 +14,28 @@ spec:
   parentRefs:
     - name: my-gateway
       namespace: gateway-infra
+      port: 443
+      sectionName: https
   hostnames:
     - ld-relay.local
   rules:
     -
       matches:
-        - path:
+        - headers:
+          - name: X-Env
+            value: production
+          method: GET
+          path:
             type: PathPrefix
             value: /api
+      filters:
+        - requestHeaderModifier:
+            set:
+            - name: X-Relay
+              value: relay-proxy
+          type: RequestHeaderModifier
+      timeouts:
+        request: 5s
       backendRefs:
         - name: ld-relay-test
           port: 8030
@@ -29,7 +43,8 @@ spec:
       matches:
         - path:
             type: PathPrefix
-            value: /prometheus
+            value: /
       backendRefs:
         - name: ld-relay-test
-          port: 8031
+          port: 8030
+          weight: 100

--- a/test/golden/httproute.yaml
+++ b/test/golden/httproute.yaml
@@ -1,0 +1,35 @@
+---
+# Source: ld-relay/templates/httproute.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ld-relay-test
+  namespace: ld-relay-test-ns
+  labels:
+    app.kubernetes.io/name: ld-relay
+    app.kubernetes.io/instance: ld-relay-test
+    app.kubernetes.io/version: "8.19.1"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  parentRefs:
+    - name: my-gateway
+      namespace: gateway-infra
+  hostnames:
+    - "ld-relay.local"
+  rules:
+    -
+      matches:
+        - path:
+            type: PathPrefix
+            value: /api
+      backendRefs:
+        - name: ld-relay-test
+          port: 8030
+    -
+      matches:
+        - path:
+            type: PathPrefix
+            value: /prometheus
+      backendRefs:
+        - name: ld-relay-test
+          port: 8031

--- a/test/goldenfiles_test.go
+++ b/test/goldenfiles_test.go
@@ -83,3 +83,46 @@ func TestGoldenHTTPRouteWithBaseConfiguration(t *testing.T) {
 		},
 	})
 }
+
+func TestGoldenHTTPRouteWithFullSchema(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../")
+	require.NoError(t, err)
+
+	suite.Run(t, &TemplateGoldenTest{
+		ChartPath:      chartPath,
+		Release:        "ld-relay-test",
+		Namespace:      goldenNamespace,
+		GoldenFileName: "httproute-full",
+		Templates:      []string{"templates/httproute.yaml"},
+		SetValues: map[string]string{
+			"httpRoute.enabled":                   "true",
+			"httpRoute.parentRefs[0].name":        "my-gateway",
+			"httpRoute.parentRefs[0].namespace":   "gateway-infra",
+			"httpRoute.parentRefs[0].sectionName": "https",
+			"httpRoute.parentRefs[0].port":        "443",
+			"httpRoute.hostnames[0]":              "ld-relay.local",
+
+			// Rich match (path + headers + method), a filter, and timeouts,
+			// all passed through verbatim; backend defaulted from `port`.
+			"httpRoute.rules[0].matches[0].path.type":                          "PathPrefix",
+			"httpRoute.rules[0].matches[0].path.value":                         "/api",
+			"httpRoute.rules[0].matches[0].headers[0].name":                    "X-Env",
+			"httpRoute.rules[0].matches[0].headers[0].value":                   "production",
+			"httpRoute.rules[0].matches[0].method":                             "GET",
+			"httpRoute.rules[0].filters[0].type":                               "RequestHeaderModifier",
+			"httpRoute.rules[0].filters[0].requestHeaderModifier.set[0].name":  "X-Relay",
+			"httpRoute.rules[0].filters[0].requestHeaderModifier.set[0].value": "relay-proxy",
+			"httpRoute.rules[0].timeouts.request":                              "5s",
+			"httpRoute.rules[0].port":                                          "8030",
+
+			// Explicit weighted backend override.
+			"httpRoute.rules[1].matches[0].path.type":  "PathPrefix",
+			"httpRoute.rules[1].matches[0].path.value": "/",
+			"httpRoute.rules[1].backendRefs[0].name":   "ld-relay-test",
+			"httpRoute.rules[1].backendRefs[0].port":   "8030",
+			"httpRoute.rules[1].backendRefs[0].weight": "100",
+		},
+	})
+}

--- a/test/goldenfiles_test.go
+++ b/test/goldenfiles_test.go
@@ -54,3 +54,32 @@ func TestGoldenIngressWithBaseConfiguration(t *testing.T) {
 		},
 	})
 }
+
+func TestGoldenHTTPRouteWithBaseConfiguration(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../")
+	require.NoError(t, err)
+
+	suite.Run(t, &TemplateGoldenTest{
+		ChartPath:      chartPath,
+		Release:        "ld-relay-test",
+		Namespace:      goldenNamespace,
+		GoldenFileName: "httproute",
+		Templates:      []string{"templates/httproute.yaml"},
+		SetValues: map[string]string{
+			"httpRoute.enabled":                 "true",
+			"httpRoute.parentRefs[0].name":      "my-gateway",
+			"httpRoute.parentRefs[0].namespace": "gateway-infra",
+			"httpRoute.hostnames[0]":            "ld-relay.local",
+
+			"httpRoute.rules[0].matches[0].path.type":  "PathPrefix",
+			"httpRoute.rules[0].matches[0].path.value": "/api",
+			"httpRoute.rules[0].port":                  "8030",
+
+			"httpRoute.rules[1].matches[0].path.type":  "PathPrefix",
+			"httpRoute.rules[1].matches[0].path.value": "/prometheus",
+			"httpRoute.rules[1].port":                  "8031",
+		},
+	})
+}

--- a/test/httproute_test.go
+++ b/test/httproute_test.go
@@ -1,0 +1,43 @@
+package test
+
+import (
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+)
+
+func (s *TemplateTest) TestHTTPRouteNamespace() {
+	s.assertTemplateNamespaces("HTTPRoute", "templates/httproute.yaml", map[string]string{
+		"httpRoute.enabled":                        "true",
+		"httpRoute.hostnames[0]":                   "ld-relay.local",
+		"httpRoute.rules[0].matches[0].path.type":  "PathPrefix",
+		"httpRoute.rules[0].matches[0].path.value": "/",
+		"httpRoute.rules[0].port":                  "8030",
+	})
+}
+
+type httpRouteLabels struct {
+	Metadata struct {
+		Labels map[string]string `json:"labels"`
+	} `json:"metadata"`
+}
+
+func (s *TemplateTest) TestHTTPRouteCanSetCommonLabels() {
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"httpRoute.enabled":                        "true",
+			"httpRoute.rules[0].matches[0].path.type":  "PathPrefix",
+			"httpRoute.rules[0].matches[0].path.value": "/",
+			"httpRoute.rules[0].port":                  "8030",
+			"commonLabels.environment":                 "production",
+			"commonLabels.team":                        "platform",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.Namespace),
+	}
+
+	output := helm.RenderTemplate(s.T(), options, s.ChartPath, s.Release, []string{"templates/httproute.yaml"})
+	var route httpRouteLabels
+	helm.UnmarshalK8SYaml(s.T(), output, &route)
+
+	s.Require().Equal("production", route.Metadata.Labels["environment"])
+	s.Require().Equal("platform", route.Metadata.Labels["team"])
+}

--- a/test/httproute_test.go
+++ b/test/httproute_test.go
@@ -1,6 +1,9 @@
 package test
 
 import (
+	"os/exec"
+	"path/filepath"
+
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 )
@@ -40,4 +43,231 @@ func (s *TemplateTest) TestHTTPRouteCanSetCommonLabels() {
 
 	s.Require().Equal("production", route.Metadata.Labels["environment"])
 	s.Require().Equal("platform", route.Metadata.Labels["team"])
+}
+
+type httpRouteSpec struct {
+	Metadata struct {
+		Name        string            `json:"name"`
+		Annotations map[string]string `json:"annotations"`
+	} `json:"metadata"`
+	Spec struct {
+		Hostnames []string `json:"hostnames"`
+		Rules     []struct {
+			BackendRefs []struct {
+				Name   string `json:"name"`
+				Port   int    `json:"port"`
+				Weight int    `json:"weight"`
+			} `json:"backendRefs"`
+		} `json:"rules"`
+	} `json:"spec"`
+}
+
+// TestHTTPRouteDefaultBackendUsesChartService verifies the `port` convenience:
+// when a rule gives only a port (no explicit backendRefs), the backend is
+// synthesized to point at this chart's own Service. The Service name is the
+// computed fullname, which is also the HTTPRoute's own name, so the two must
+// match.
+func (s *TemplateTest) TestHTTPRouteDefaultBackendUsesChartService() {
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"httpRoute.enabled":                        "true",
+			"httpRoute.rules[0].matches[0].path.type":  "PathPrefix",
+			"httpRoute.rules[0].matches[0].path.value": "/",
+			"httpRoute.rules[0].port":                  "8030",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.Namespace),
+	}
+
+	output := helm.RenderTemplate(s.T(), options, s.ChartPath, s.Release, []string{"templates/httproute.yaml"})
+	var route httpRouteSpec
+	helm.UnmarshalK8SYaml(s.T(), output, &route)
+
+	s.Require().Len(route.Spec.Rules, 1)
+	s.Require().Len(route.Spec.Rules[0].BackendRefs, 1)
+	backend := route.Spec.Rules[0].BackendRefs[0]
+	s.Require().Equal(route.Metadata.Name, backend.Name, "default backend must point at this chart's own Service")
+	s.Require().Equal(8030, backend.Port)
+}
+
+// TestHTTPRouteAnnotations verifies httpRoute.annotations render onto the
+// resource metadata.
+func (s *TemplateTest) TestHTTPRouteAnnotations() {
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"httpRoute.enabled":                        "true",
+			"httpRoute.annotations.example\\.com/team": "platform",
+			"httpRoute.rules[0].matches[0].path.type":  "PathPrefix",
+			"httpRoute.rules[0].matches[0].path.value": "/",
+			"httpRoute.rules[0].port":                  "8030",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.Namespace),
+	}
+
+	output := helm.RenderTemplate(s.T(), options, s.ChartPath, s.Release, []string{"templates/httproute.yaml"})
+	var route httpRouteSpec
+	helm.UnmarshalK8SYaml(s.T(), output, &route)
+
+	s.Require().Equal("platform", route.Metadata.Annotations["example.com/team"])
+}
+
+// TestHTTPRouteHostnamesQuoting verifies hostnames render as valid YAML,
+// including a wildcard hostname that requires quoting (a bare `- *.foo` would be
+// an invalid YAML alias). Successful unmarshal plus the preserved value proves
+// the toYaml rendering quotes where needed.
+func (s *TemplateTest) TestHTTPRouteHostnamesQuoting() {
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"httpRoute.enabled":       "true",
+			"httpRoute.hostnames[0]":  "*.ld-relay.local",
+			"httpRoute.hostnames[1]":  "ld-relay.local",
+			"httpRoute.rules[0].port": "8030",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.Namespace),
+	}
+
+	output := helm.RenderTemplate(s.T(), options, s.ChartPath, s.Release, []string{"templates/httproute.yaml"})
+	var route httpRouteSpec
+	helm.UnmarshalK8SYaml(s.T(), output, &route)
+
+	s.Require().Equal([]string{"*.ld-relay.local", "ld-relay.local"}, route.Spec.Hostnames)
+}
+
+// TestHTTPRoutePathlessMatch verifies that a match without a `path` (a valid
+// Gateway API match that constrains only headers/method/queryParams) renders
+// instead of crashing the template with a nil-pointer dereference.
+func (s *TemplateTest) TestHTTPRoutePathlessMatch() {
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"httpRoute.enabled":                              "true",
+			"httpRoute.parentRefs[0].name":                   "my-gateway",
+			"httpRoute.rules[0].matches[0].headers[0].name":  "X-Env",
+			"httpRoute.rules[0].matches[0].headers[0].value": "prod",
+			"httpRoute.rules[0].port":                        "8030",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.Namespace),
+	}
+
+	output, err := helm.RenderTemplateE(s.T(), options, s.ChartPath, s.Release,
+		[]string{"templates/httproute.yaml"})
+
+	s.Require().NoError(err, "a header-only match (no path) must not crash the template")
+	s.Require().Contains(output, "kind: HTTPRoute")
+}
+
+// TestHTTPRouteBackendRefsOverride verifies that an explicit backendRefs takes
+// precedence over the `port` convenience default (which points at the chart
+// Service), enabling weighting / mirroring / external backends.
+func (s *TemplateTest) TestHTTPRouteBackendRefsOverride() {
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"httpRoute.enabled":                        "true",
+			"httpRoute.rules[0].matches[0].path.type":  "PathPrefix",
+			"httpRoute.rules[0].matches[0].path.value": "/",
+			"httpRoute.rules[0].backendRefs[0].name":   "external-svc",
+			"httpRoute.rules[0].backendRefs[0].port":   "9000",
+			"httpRoute.rules[0].backendRefs[0].weight": "100",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.Namespace),
+	}
+
+	output := helm.RenderTemplate(s.T(), options, s.ChartPath, s.Release, []string{"templates/httproute.yaml"})
+	var route httpRouteSpec
+	helm.UnmarshalK8SYaml(s.T(), output, &route)
+
+	s.Require().Len(route.Spec.Rules, 1)
+	s.Require().Len(route.Spec.Rules[0].BackendRefs, 1)
+	backend := route.Spec.Rules[0].BackendRefs[0]
+	s.Require().Equal("external-svc", backend.Name, "explicit backendRefs must not be overwritten by the chart Service default")
+	s.Require().Equal(9000, backend.Port)
+	s.Require().Equal(100, backend.Weight)
+}
+
+// TestHTTPRouteRuleRequiresBackend verifies the guard that fails the render when
+// a rule specifies neither a `port` nor explicit `backendRefs`, surfacing the
+// mistake at template time instead of rendering an invalid null backend port.
+func (s *TemplateTest) TestHTTPRouteRuleRequiresBackend() {
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"httpRoute.enabled":                        "true",
+			"httpRoute.rules[0].matches[0].path.type":  "PathPrefix",
+			"httpRoute.rules[0].matches[0].path.value": "/",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.Namespace),
+	}
+
+	_, err := helm.RenderTemplateE(s.T(), options, s.ChartPath, s.Release,
+		[]string{"templates/httproute.yaml"})
+
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "needs a `port`")
+}
+
+// TestHTTPRouteParentRefsPassThrough verifies parentRefs render the full
+// ParentReference schema -- including `port` and `sectionName`, which the
+// previous hand-rendered template dropped.
+func (s *TemplateTest) TestHTTPRouteParentRefsPassThrough() {
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"httpRoute.enabled":                        "true",
+			"httpRoute.parentRefs[0].name":             "my-gateway",
+			"httpRoute.parentRefs[0].namespace":        "gateway-infra",
+			"httpRoute.parentRefs[0].sectionName":      "https",
+			"httpRoute.parentRefs[0].port":             "443",
+			"httpRoute.rules[0].matches[0].path.type":  "PathPrefix",
+			"httpRoute.rules[0].matches[0].path.value": "/",
+			"httpRoute.rules[0].port":                  "8030",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.Namespace),
+	}
+
+	output := helm.RenderTemplate(s.T(), options, s.ChartPath, s.Release, []string{"templates/httproute.yaml"})
+
+	s.Require().Contains(output, "sectionName: https")
+	s.Require().Contains(output, "port: 443")
+}
+
+// TestHTTPRoutePortNotInjectable verifies that a rule's `port` is coerced to an
+// integer, so a string port carrying a YAML-injection payload (newline + a fake
+// sibling key) cannot inject keys into the rendered backendRef.
+func (s *TemplateTest) TestHTTPRoutePortNotInjectable() {
+	valuesFile, err := filepath.Abs("testdata/httproute_port_injection.yaml")
+	s.Require().NoError(err)
+
+	options := &helm.Options{
+		ValuesFiles:    []string{valuesFile},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.Namespace),
+	}
+
+	output := helm.RenderTemplate(s.T(), options, s.ChartPath, s.Release, []string{"templates/httproute.yaml"})
+
+	s.Require().NotContains(output, "injected")
+	s.Require().NotContains(output, "pwned")
+	var route httpRouteSpec
+	helm.UnmarshalK8SYaml(s.T(), output, &route)
+	s.Require().Len(route.Spec.Rules, 1)
+	s.Require().Len(route.Spec.Rules[0].BackendRefs, 1)
+}
+
+// TestHTTPRouteNotesHeaderOnlyMatch renders NOTES.txt (via `helm install
+// --dry-run`, since `helm template` omits NOTES) for a header-only match. This
+// locks in the NOTES `.path`/`.value` guard against regression: a match with no
+// path must not nil-panic, must reach the httproute guidance, and must not fall
+// through to the ClusterIP port-forward branch.
+func (s *TemplateTest) TestHTTPRouteNotesHeaderOnlyMatch() {
+	cmd := exec.Command("helm", "install", s.Release, s.ChartPath,
+		"--dry-run=client", "--namespace", s.Namespace,
+		"--set", "httpRoute.enabled=true",
+		"--set", "httpRoute.rules[0].matches[0].headers[0].name=X-Env",
+		"--set", "httpRoute.rules[0].matches[0].headers[0].value=prod",
+		"--set", "httpRoute.rules[0].port=8030",
+	)
+	out, err := cmd.CombinedOutput()
+	s.Require().NoError(err, string(out))
+
+	notes := string(out)
+	// Assert on text unique to the HTTPRoute NOTES branch (not just "httproute",
+	// which also appears in the rendered manifest dump), and confirm we did not
+	// fall through to the ClusterIP port-forward branch.
+	s.Require().Contains(notes, "configured on your Gateway")
+	s.Require().NotContains(notes, "port-forward")
 }

--- a/test/testdata/httproute_port_injection.yaml
+++ b/test/testdata/httproute_port_injection.yaml
@@ -1,0 +1,11 @@
+# Regression fixture: a string `port` carrying a YAML-injection payload (a
+# newline plus a fake sibling key). The template must coerce `port` to an
+# integer so the payload cannot inject keys into the rendered backendRef.
+httpRoute:
+  enabled: true
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      port: "8030\n          injected: pwned"

--- a/values.yaml
+++ b/values.yaml
@@ -154,16 +154,32 @@ ingress:
 httpRoute:
   enabled: false
   annotations: {}
-  # Gateway(s) this HTTPRoute attaches to.
+  # Gateway(s) this HTTPRoute attaches to. Rendered as-is, so the full Gateway
+  # API ParentReference schema is available (name, namespace, sectionName, port).
   parentRefs: []
   #   - name: my-gateway
   #     namespace: gateway-infra
   #     sectionName: https
+  #     port: 443
   # Hostnames this route matches. If unset, the route matches based on the
   # Gateway's listener hostname.
   hostnames: []
   #   - ld-relay.local
-  # Exposing the relay allows for access outside the cluster
+  # Routing rules. `matches`, `filters`, and `timeouts` are passed through
+  # verbatim, so the full Gateway API HTTPRoute rule schema is available.
+  # Exposing the relay allows for access outside the cluster.
+  #
+  # Backend selection, per rule:
+  #   - Set `port` to route to this chart's own Service (safe default).
+  #   - Or set `backendRefs` explicitly for weighting, mirroring, or an external
+  #     backend. `backendRefs` takes precedence: if you set both, `port` is
+  #     ignored. Unlike `port`, an explicit `backendRefs` can point at any
+  #     Service (including another namespace), so the relay's hostname could be
+  #     routed somewhere other than this relay -- use it deliberately.
+  #
+  # A rule with no `matches` matches EVERY request (Gateway API default), which
+  # publishes the entire relay -- including admin/metrics endpoints -- on the
+  # route's hostname. Add an explicit `matches` unless you intend a catch-all.
   rules: []
   #   - matches:
   #       - path:
@@ -176,6 +192,34 @@ httpRoute:
   #           type: PathPrefix
   #           value: /prometheus
   #     port: 8031
+  # The full rule schema is supported -- header/method/query matches, filters,
+  # and timeouts:
+  #   - matches:
+  #       - path:
+  #           type: PathPrefix
+  #           value: /api
+  #         headers:
+  #           - name: X-Env
+  #             value: production
+  #         method: GET
+  #     filters:
+  #       - type: RequestHeaderModifier
+  #         requestHeaderModifier:
+  #           set:
+  #             - name: X-Relay
+  #               value: relay-proxy
+  #     timeouts:
+  #       request: 5s
+  #     port: 8030
+  # Or take full control of the backend (traffic splitting, mirroring):
+  #   - matches:
+  #       - path:
+  #           type: PathPrefix
+  #           value: /
+  #     backendRefs:
+  #       - name: ld-relay
+  #         port: 8030
+  #         weight: 100
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/values.yaml
+++ b/values.yaml
@@ -151,6 +151,32 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+httpRoute:
+  enabled: false
+  annotations: {}
+  # Gateway(s) this HTTPRoute attaches to.
+  parentRefs: []
+  #   - name: my-gateway
+  #     namespace: gateway-infra
+  #     sectionName: https
+  # Hostnames this route matches. If unset, the route matches based on the
+  # Gateway's listener hostname.
+  hostnames: []
+  #   - ld-relay.local
+  # Exposing the relay allows for access outside the cluster
+  rules: []
+  #   - matches:
+  #       - path:
+  #           type: PathPrefix
+  #           value: /
+  #     port: 8030
+  # You may optionally need to expose the Prometheus endpoint as well
+  #   - matches:
+  #       - path:
+  #           type: PathPrefix
+  #           value: /prometheus
+  #     port: 8031
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
Adds an httproute.yaml template and httpRoute values block so the chart can expose the relay via a Gateway API HTTPRoute, alongside the existing Ingress option.

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

IDE-3448

**Describe the solution you've provided**

Allows providing HTTPRoute crd options, alongside the original ingress annotation

**Describe alternatives you've considered**

None

**Additional context**

Add any other context about the pull request here.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Misconfigured rules (especially catch-all matches or external backendRefs) can expose relay or admin/metrics traffic outside the cluster; the feature is opt-in and includes render-time validation plus port coercion.
> 
> **Overview**
> Adds **optional Gateway API** exposure for the Relay Proxy via a new `httpRoute` values block and `templates/httproute.yaml`, as an alternative to the existing Ingress path (documented as use one or the other).
> 
> When `httpRoute.enabled` is true, the chart renders a `gateway.networking.k8s.io/v1` **HTTPRoute** with `parentRefs`, `hostnames`, and rules. Gateway API **matches**, **filters**, and **timeouts** pass through from values; each rule must set **`port`** (chart synthesizes a `backendRefs` entry to this release’s Service) or explicit **`backendRefs`** (which override `port`). Template-time **`fail`** guards missing backends, and **`port | int`** blocks YAML-injection via crafted port strings.
> 
> **`NOTES.txt`** gains an `httpRoute` branch that prints guessed URLs from hostname + path matches (with safe handling when matches have no path) or points operators at `kubectl get httproute`. **README** and **`values.yaml`** document the new knobs and catch-all exposure risk.
> 
> Coverage includes golden fixtures, Terratest for labels/namespace/backends/parentRefs, and a NOTES dry-run test for header-only matches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc847c679f47e2fc165bff7ca52e0dbd7a79c3e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->